### PR TITLE
Re-instance empty containers to prevent contamination

### DIFF
--- a/jmesflat/__init__.py
+++ b/jmesflat/__init__.py
@@ -12,7 +12,7 @@ Key features:
 - Support for spaces and special characters in keys
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 from . import constants, utils
 from ._clean import clean
@@ -20,4 +20,12 @@ from ._flatten import flatten
 from ._merge import merge, LevelMatchFunc
 from ._unflatten import unflatten
 
-__all__ = ["clean", "constants", "flatten", "merge", "unflatten", "utils", "LevelMatchFunc"]
+__all__ = [
+    "clean",
+    "constants",
+    "flatten",
+    "merge",
+    "unflatten",
+    "utils",
+    "LevelMatchFunc",
+]

--- a/jmesflat/_flatten.py
+++ b/jmesflat/_flatten.py
@@ -74,6 +74,10 @@ def flatten(
             return
         flat_key = utils.flat_key_from_path_elements(_parent_keys)
         if not (callable(discard_check) and discard_check(flat_key, this_entry)):
+            if isinstance(this_entry, (dict, list)) and not this_entry:
+                # copy empty containers so the flattened output never aliases
+                # (and can never be used to mutate) the input's leaf objects
+                this_entry = type(this_entry)()
             _out_dict[flat_key] = this_entry
 
     out_dict: dict[str, Any] = {}
@@ -85,7 +89,9 @@ def flatten(
         if not isinstance(val, constants.ATOMIC_TYPES) and not empty_container:
             _recurs_flatten(nested, [key], out_dict)
         elif not (callable(discard_check) and discard_check(flat_key, val)):
-            out_dict[flat_key] = val
+            # copy empty containers so the flattened output never aliases
+            # (and can never be used to mutate) the input's leaf objects
+            out_dict[flat_key] = type(val)() if empty_container else val
 
     return return_type(
         sorted(out_dict.items(), key=lambda x: utils.raw_jpquery_path_elements(x[0]))

--- a/jmesflat/_unflatten.py
+++ b/jmesflat/_unflatten.py
@@ -136,5 +136,11 @@ def unflatten(
             path = f"__top__{path}"
         if callable(discard_check) and discard_check(path, value):
             continue
+        if isinstance(value, (dict, list)) and not value:
+            # copy empty containers before planting them: deeper sibling keys
+            # descend INTO the planted object, and inserting into a caller
+            # supplied `{}`/`[]` would mutate the input (and anything that
+            # shares a reference to it)
+            value = type(value)()
         _update_nest(path, value, out_dict)
     return out_dict.pop("__top__") if pop_top else out_dict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,12 @@ classifiers = [
 ]
 dependencies = ["jmespath"]
 
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.0.0",
+  "pytest-cov>=4.0.0"
+]
+
 [project.urls]
 Home = "https://github.com/hank-ai/jmesflat"
 Issues = "https://github.com/hank-ai/jmesflat/issues"

--- a/tests/test_mutation_safety.py
+++ b/tests/test_mutation_safety.py
@@ -1,0 +1,71 @@
+"""Regression tests: flatten/unflatten/merge must not alias or mutate
+empty-container leaves from their inputs.
+
+Background: `flatten` emits empty dict/list leaves *by reference* and
+`unflatten` plants leaf values by reference, then descends into them when
+deeper sibling keys exist. As a result, `merge(base, overlay)` could insert
+overlay values INTO a shared `{}`/`[]` object inside `base`, permanently
+mutating it and contaminating every other structure that aliased that object.
+"""
+
+import copy
+
+import jmesflat as jf
+
+
+def test_flatten_copies_empty_dict_leaf():
+    """Empty-container leaves in flatten output must not be the input objects"""
+    nested = {"outer": {"inner": {}}}
+    flat = jf.flatten(nested)
+    assert flat["outer.inner"] == {}
+    assert flat["outer.inner"] is not nested["outer"]["inner"]
+
+
+def test_flatten_copies_empty_list_leaf():
+    """Empty list leaves must be copied too, including at the top level"""
+    nested = {"top": [], "outer": {"inner": []}}
+    flat = jf.flatten(nested)
+    assert flat["top"] is not nested["top"]
+    assert flat["outer.inner"] is not nested["outer"]["inner"]
+
+
+def test_unflatten_does_not_mutate_input_empty_dict_leaf():
+    """Deeper sibling keys must not be inserted into the caller's `{}` object"""
+    shared_empty: dict = {}
+    flat = {"settings.required": shared_empty, "settings.required.note": "value"}
+    result = jf.unflatten(flat)
+    assert result == {"settings": {"required": {"note": "value"}}}
+    assert shared_empty == {}
+
+
+def test_unflatten_does_not_mutate_input_empty_list_leaf():
+    """Deeper sibling array keys must not be appended into the caller's `[]`"""
+    shared_empty: list = []
+    flat = {"settings.items": shared_empty, "settings.items[0]": "value"}
+    result = jf.unflatten(flat)
+    assert result == {"settings": {"items": ["value"]}}
+    assert shared_empty == []
+
+
+def test_merge_does_not_mutate_nest1_via_empty_dict_leaf():
+    """The pdf-extractor contamination shape: overlay keys beneath an
+    empty-dict leaf in nest1 must not be written back into nest1"""
+    base = {"hreExtractionSettings": {"requiredNoteTypes": {}}}
+    base_snapshot = copy.deepcopy(base)
+    overlay = {
+        "hreExtractionSettings": {
+            "requiredNoteTypes": {"SurgeonProcedureNote": ["SurgeonProcedureNote"]}
+        }
+    }
+    merged = jf.merge(base, overlay, array_merge="deduped")
+    assert merged == overlay
+    assert base == base_snapshot
+
+
+def test_merge_result_does_not_alias_nest1_empty_containers():
+    """Mutating an empty container in the merge result must not affect nest1"""
+    base = {"settings": {"required": {}, "items": []}}
+    merged = jf.merge(base, {"other": 1})
+    merged["settings"]["required"]["note"] = "value"
+    merged["settings"]["items"].append("entry")
+    assert base == {"settings": {"required": {}, "items": []}}


### PR DESCRIPTION
Prior to this fix, empty containers were treated as 'atomic' types and passed forward by reference. If nest1 contained an empty container for which nest2 contained members, a merge would contaminate all references to the original shared container.